### PR TITLE
add function in rwops to read bitrmap from memory and an example to test

### DIFF
--- a/examples/alpha/alpha1.f90
+++ b/examples/alpha/alpha1.f90
@@ -1,0 +1,108 @@
+! alpha1.f90
+!
+! Makes one color of an image transparent.
+! using an embedded image
+! Author:  Philipp Engel
+! GitHub:  https://github.com/interkosmos/fortran-sdl2/
+! Licence: ISC
+
+! generate the object file to be embedded using the following
+! objcopy --input binary --output elf64-x86-64 --binary-architecture i386 --redefine-sym _binary_fortran_bmp_start=img_start --redefine-sym _binary_fortran_bmp_end=img_end --redefine-sym _binary_fortran_bmp_size=img_size fortran.bmp fortran.o
+! the size of this file is 61610, hard coded below
+module data
+use iso_c_binding
+implicit none
+! character(kind=c_char), target, bind(c) :: img_start
+! character(61610), pointer :: bmp
+character(kind=c_char), target, bind(c) :: img_start
+character(61610), pointer :: bmp
+end module data
+
+program main
+    use, intrinsic :: iso_c_binding, only: c_associated, c_null_char, c_ptr, c_f_pointer, c_loc
+    use, intrinsic :: iso_fortran_env, only: stdout => output_unit, stderr => error_unit
+    use :: sdl2
+    use :: data
+    implicit none
+
+    integer,          parameter :: WIDTH     = 640
+    integer,          parameter :: HEIGHT    = 240
+    ! character(len=*), parameter :: FILE_NAME = 'fortran.bmp'
+
+    type(c_ptr)                     :: window
+    type(sdl_surface),      pointer :: window_surface
+    type(sdl_surface),      pointer :: image_loaded
+    type(sdl_surface),      pointer :: image_optimised
+    type(sdl_pixel_format), pointer :: pixel_format
+    type(sdl_rect)                  :: window_rect
+    type(sdl_rect)                  :: image_rect
+    type(sdl_event)                 :: event
+    integer                         :: color
+    integer                         :: rc
+    logical                         :: done = .false.
+    type(c_ptr)                     :: ptr
+
+    ! Initialise SDL.
+    rc = sdl_init(SDL_INIT_VIDEO)
+
+    if (rc < 0) then
+        write (stderr, *) 'SDL Error: ', sdl_get_error()
+        stop
+    end if
+
+    ! Create the SDL window.
+    window = sdl_create_window('Fortran SDL 2.0' // c_null_char, &
+                               SDL_WINDOWPOS_UNDEFINED, &
+                               SDL_WINDOWPOS_UNDEFINED, &
+                               WIDTH, &
+                               HEIGHT, &
+                               SDL_WINDOW_SHOWN)
+
+    if (.not. c_associated(window)) then
+        write (stderr, *) 'SDL Error: ', sdl_get_error()
+        stop
+    end if
+
+    window_surface  => sdl_get_window_surface(window)                     ! Get surface of window.
+
+    !
+    call c_f_pointer(c_loc(img_start), bmp)
+    ptr = sdl_load_bmp_rw(sdl_rw_from_const_mem(bmp, 61610), 1) ! Load embedded BMP.
+    call c_f_pointer(ptr, image_loaded)
+
+    pixel_format    => sdl_get_pixel_format(window_surface)               ! Get pixel format of window.
+    image_optimised => sdl_convert_surface(image_loaded, pixel_format, 0) ! Optimise pixel format of image.
+    color           = sdl_map_rgb(pixel_format, 255, 0, 255)              ! Get translucent color (#FF00FF).
+    rc              = sdl_set_color_key(image_optimised, 1, color)        ! Set translucent color.
+
+    window_rect%w = WIDTH
+    window_rect%h = HEIGHT
+    window_rect%x = 25
+    window_rect%y = 25
+
+    image_rect%w = image_optimised%w
+    image_rect%h = image_optimised%h
+    image_rect%x = 0
+    image_rect%y = 0
+
+    do while (.not. done)
+        rc = sdl_poll_event(event)
+
+        if (rc > 0) then
+            select case (event%type)
+                case (SDL_QUITEVENT)
+                    done = .true.
+            end select
+        end if
+
+        ! Draw the image and update the window surface.
+        rc = sdl_blit_surface(image_optimised, image_rect, window_surface, window_rect)
+        rc = sdl_update_window_surface(window)
+    end do
+
+    ! Quit gracefully.
+    call sdl_free_surface(image_optimised)
+    call sdl_free_surface(image_loaded)
+    call sdl_destroy_window(window)
+    call sdl_quit()
+end program main

--- a/examples/fire/fire.f90
+++ b/examples/fire/fire.f90
@@ -7,7 +7,7 @@
 ! GitHub:  https://github.com/interkosmos/fortran-sdl2/
 ! Licence: ISC
 module doom
-    implicit  none
+    implicit none
 
     type :: rgb_type
         integer :: r = 0
@@ -103,6 +103,8 @@ program main
 
     integer, parameter :: SCREEN_WIDTH  = 640
     integer, parameter :: SCREEN_HEIGHT = 400
+    integer, parameter :: FIRE_WIDTH    = SCREEN_WIDTH / 2
+    integer, parameter :: FIRE_HEIGHT   = SCREEN_HEIGHT / 2
 
     type :: buffer_type
         integer                          :: format       ! Texture format.
@@ -120,7 +122,8 @@ program main
     type(c_ptr)       :: renderer
     type(c_ptr)       :: window
     type(sdl_event)   :: event
-    integer           :: fire(SCREEN_WIDTH * SCREEN_HEIGHT)
+    type(sdl_rect)    :: screen_rect
+    integer           :: fire(FIRE_WIDTH * FIRE_HEIGHT)
     integer           :: rc
 
     ! Initialise PRNG.
@@ -148,9 +151,11 @@ program main
     ! Create renderer.
     renderer = sdl_create_renderer(window, -1, ior(SDL_RENDERER_ACCELERATED, &
                                                    SDL_RENDERER_PRESENTVSYNC))
+    screen_rect = sdl_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
+
     ! Create frame buffer texture.
-    buffer%width  = SCREEN_WIDTH
-    buffer%height = SCREEN_HEIGHT
+    buffer%width  = FIRE_WIDTH
+    buffer%height = FIRE_HEIGHT
 
     buffer%texture = sdl_create_texture(renderer, &
                                         SDL_PIXELFORMAT_ARGB8888, &
@@ -160,7 +165,6 @@ program main
 
     buffer%format = sdl_get_window_pixel_format(window)
     buffer%pixel_format => sdl_alloc_format(buffer%format)
-
     buffer%rect = sdl_rect(0, 0, buffer%width, buffer%height)
 
     ! Get texture's pixel pointers.
@@ -169,7 +173,7 @@ program main
     call sdl_unlock_texture(buffer%texture)
 
     ! Initialise fire.
-    call fire_init(fire, SCREEN_WIDTH, SCREEN_HEIGHT)
+    call fire_init(fire, FIRE_WIDTH, FIRE_HEIGHT)
 
     ! Main loop.
     loop: do
@@ -181,11 +185,11 @@ program main
             end select
         end do
 
-        call fire_burn(fire, SCREEN_WIDTH, SCREEN_HEIGHT)
-        call render(buffer, fire, SCREEN_WIDTH, SCREEN_HEIGHT)
+        call fire_burn(fire, FIRE_WIDTH, FIRE_HEIGHT)
+        call render(buffer, fire, FIRE_WIDTH, FIRE_HEIGHT)
 
         ! Copy buffer texture to screen.
-        rc = sdl_render_copy(renderer, buffer%texture, buffer%rect, buffer%rect)
+        rc = sdl_render_copy(renderer, buffer%texture, buffer%rect, screen_rect)
         call sdl_render_present(renderer)
     end do loop
 

--- a/src/sdl2/sdl2_rwops.f90
+++ b/src/sdl2/sdl2_rwops.f90
@@ -6,10 +6,10 @@
 ! GitHub:  https://github.com/interkosmos/fortran-sdl2/
 ! Licence: ISC
 module sdl2_rwops
-    use, intrinsic :: iso_c_binding, only: c_char, c_ptr
+    use, intrinsic :: iso_c_binding, only: c_char, c_ptr, c_int
     implicit none
 
-    public :: sdl_rw_from_file
+    public :: sdl_rw_from_file, sdl_rw_from_const_mem
 
     interface
         ! SDL_RWops *SDL_RWFromFile(const char *file, const char *mode)
@@ -19,5 +19,13 @@ module sdl2_rwops
             character(kind=c_char), intent(in) :: mode
             type(c_ptr)                        :: sdl_rw_from_file
         end function sdl_rw_from_file
+
+        ! SDL_RWops *SDL_RWFromMem(const void *mem, int size)
+        function sdl_rw_from_const_mem(mem, siz) bind(c, name='SDL_RWFromConstMem')
+            import :: c_char, c_ptr, c_int
+            character(kind=c_char), target, intent(in) :: mem
+            integer(kind=c_int),            intent(in) :: siz
+            type(c_ptr)                                :: sdl_rw_from_const_mem
+        end function sdl_rw_from_const_mem
     end interface
 end module sdl2_rwops


### PR DESCRIPTION
Firstly, thanks for sdl2-fortran repo. I see that a lot of work has gone into it. I was missing functions to load bitmaps from memory. I've attached one in this pull request, which proved more difficult that I initially thought (I'm new to fortran). I don't expect you to merge this but it seemed the best way to share my idea and discuss.

In order to embed a bitmap I used objdump to create an object file from fortran.bmp in the examples/alpha folder, which is then linked to the executable as described in alpha1.f90.  I'm unsure if there is a cleaner/better way to do this: f95 fortran.o alpha1.f90

Testing proved positive but fails if the memory is messed up by, for example, running alpha without the fortran.bmp present and then running alpha1 immediately after. Not sure why.